### PR TITLE
Add NLT to ExtractorBindingPattern and ExtractorMemberExpression

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -914,9 +914,9 @@ contributors: Ron Buckton, Ecma International
 
         <ins class="block">
         ExtractorAssignmentPattern[Yield, Await] :
-          ExtractorMemberExpression[?Yield, ?Await] `(` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` AssignmentElementList[?Yield, ?Await] `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` AssignmentElementList[?Yield, ?Await] `,` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await, +Assignment] `(` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await, +Assignment] `(` AssignmentElementList[?Yield, ?Await] `)`
+          ExtractorMemberExpression[?Yield, ?Await, +Assignment] `(` AssignmentElementList[?Yield, ?Await] `,` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
         </ins>
 
         AssignmentRestProperty[Yield, Await] :
@@ -1284,18 +1284,19 @@ contributors: Ron Buckton, Ecma International
         <ins class="block">
         <emu-grammar type="definition">
         ExtractorBindingPattern[Yield, Await] :
-          ExtractorMemberExpression[?Yield, ?Await] `(` Elision? BindingRestElement[?Yield, ?Await]? `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` BindingElementList[?Yield, ?Await] `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` BindingElementList[?Yield, ?Await] `,` Elision? BindingRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await, ~Assignment] [no |LineTerminator| here] `(` Elision? BindingRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await, ~Assignment] [no |LineTerminator| here] `(` BindingElementList[?Yield, ?Await] `)`
+          ExtractorMemberExpression[?Yield, ?Await, ~Assignment] [no |LineTerminator| here] `(` BindingElementList[?Yield, ?Await] `,` Elision? BindingRestElement[?Yield, ?Await]? `)`
 
-        ExtractorMemberExpression[Yield, Await] :
+        ExtractorMemberExpression[Yield, Await, Assignment] :
           `this`
           MetaProperty
           IdentifierReference[?Yield, ?Await]
           `super` `.` IdentifierName
-          ExtractorMemberExpression[?Yield, ?Await] `.` IdentifierName
-          ExtractorMemberExpression[?Yield, ?Await] `.` PrivateIdentifier
-          ExtractorMemberExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
+          ExtractorMemberExpression[?Yield, ?Await, ?Assignment] `.` IdentifierName
+          ExtractorMemberExpression[?Yield, ?Await, ?Assignment] `.` PrivateIdentifier
+          [+Assignment] ExtractorMemberExpression[?Yield, ?Await, ?Assignment] `[` Expression[+In, ?Yield, ?Await] `]`
+          [~Assignment] ExtractorMemberExpression[?Yield, ?Await, ?Assignment] [no |LineTerminator| here] `[` Expression[+In, ?Yield, ?Await] `]`
         </emu-grammar>
         <emu-note type="editor">
           <p>Draft Note: The |ExtractorMemberExpression| production is equivalent to <a href="https://tc39.es/proposal-pattern-matching/#prod-PatternMatchingMemberExpression">PatternMatchingMemberExpression</a> in the <a href="https://github.com/tc39/proposal-pattern-matching">Pattern Matching</a> proposal.</p>


### PR DESCRIPTION
This adds a `[no |LineTerminator| here]` assertion to _ExtractorBindingPattern_ and to _ExtractorMemberExpression_ and introduces a new `[Assertion]` production parameter to _ExtractorMemberExpression_ to align with Option (1) as discussed in #24:

> 1. Introduce an NLT in _ExtractorBindingPattern_ but not _ExtractorAssignmentPattern_.

This is an _alternative_ solution to the one implemented in #27.

The outcome of this change is as follows:

- For
  ```js
  let x
  (a) = b
  ```
  the source is interpreted as `let x; (a) = b;` due to the NLT assertion and ASI.

- For
  ```js
  let x
  [a](b) = c
  ```
  the source is interpreted as `let x; [a](b) = c;` due to the NLT assertion and ASI. Note that `[a](b)` is not a valid _ExtractorAssignmentPattern_ as `[a]` is not a valid _ExtractorMemberExpression_ and will result in an Early Error when applying static semantics for destructuring assignment.

- For
  ```js
  let x[a]
  (b) = c
  ```
  the source is interpreted as `let x[a]; (b) = c;` due to the NLT assertion and ASI and results in a Syntax Error at parse time.

- For
  ```js
  x
  (a) = b
  ```
  the source is interpreted as `x(a) = b;` as there is no NLT restriction. This makes _ExtractorAssignmentPattern_ mildly inconsistent with _ExtractorBindingPattern_.

- For
  ```js
  x
  [a](b) = c
  ```
  the source is interpreted as `x[a](b) = c;` as there is no NLT restriction. This makes _ExtractorAssignmentPattern_ mildly inconsistent with _ExtractorBindingPattern_.

- For
  ```js
  x
  [a]
  (b) = c
  ```
  the source is interpreted as `x[a](b) = c;` as there is no NLT restriction. This makes _ExtractorAssignmentPattern_ mildly inconsistent with _ExtractorBindingPattern_.

Fixes #24
Related #27