### PR TITLE
Fix destructuring and assignment static semantics and use correct cover reference

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -958,7 +958,7 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral| or an |ObjectLiteral|.
+            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral|<del> or</del><ins>,</ins> an |ObjectLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>.
           </li>
         </ul>
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
@@ -1139,6 +1139,118 @@ contributors: Ron Buckton, Ecma International
         </emu-note>
         </ins>
       </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-iteratordestructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: IteratorDestructuringAssignmentEvaluation (
+            _iteratorRecord_: an Iterator Record,
+          ): either a normal completion containing ~unused~ or an abrupt completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>AssignmentElementList : AssignmentElisionElement</emu-grammar>
+        <emu-alg>
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| with argument _iteratorRecord_.
+        </emu-alg>
+        <emu-grammar>AssignmentElementList : AssignmentElementList `,` AssignmentElisionElement</emu-grammar>
+        <emu-alg>
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |AssignmentElementList| with argument _iteratorRecord_.
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElisionElement| with argument _iteratorRecord_.
+        </emu-alg>
+        <emu-grammar>AssignmentElisionElement : AssignmentElement</emu-grammar>
+        <emu-alg>
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with argument _iteratorRecord_.
+        </emu-alg>
+        <emu-grammar>AssignmentElisionElement : Elision AssignmentElement</emu-grammar>
+        <emu-alg>
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+          1. Return ? IteratorDestructuringAssignmentEvaluation of |AssignmentElement| with argument _iteratorRecord_.
+        </emu-alg>
+        <emu-grammar>Elision : `,`</emu-grammar>
+        <emu-alg>
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Perform ? IteratorStep(_iteratorRecord_).
+          1. Return ~unused~.
+        </emu-alg>
+        <emu-grammar>Elision : Elision `,`</emu-grammar>
+        <emu-alg>
+          1. Perform ? IteratorDestructuringAssignmentEvaluation of |Elision| with argument _iteratorRecord_.
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Perform ? IteratorStep(_iteratorRecord_).
+          1. Return ~unused~.
+        </emu-alg>
+        <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
+        <emu-alg>
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+          1. Let _value_ be *undefined*.
+          1. If _iteratorRecord_.[[Done]] is *false*, then
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is not ~done~, then
+              1. Set _value_ to _next_.
+          1. If |Initializer| is present and _value_ is *undefined*, then
+            1. If IsAnonymousFunctionDefinition(|Initializer|) is *true* and IsIdentifierRef of |DestructuringAssignmentTarget| is *true*, then
+              1. Let _v_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
+            1. Else,
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
+              1. Let _v_ be ? GetValue(_defaultValue_).
+          1. Else,
+            1. Let _v_ be _value_.
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+            1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
+            1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
+          1. Return ? PutValue(_lref_, _v_).
+        </emu-alg>
+        <emu-note>
+          <p>Left to right evaluation order is maintained by evaluating a |DestructuringAssignmentTarget| that is not a destructuring pattern prior to accessing the iterator or evaluating the |Initializer|.</p>
+        </emu-note>
+        <emu-grammar>AssignmentRestElement : `...` DestructuringAssignmentTarget</emu-grammar>
+        <emu-alg>
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+          1. Let _A_ be ! ArrayCreate(0).
+          1. Let _n_ be 0.
+          1. Repeat, while _iteratorRecord_.[[Done]] is *false*,
+            1. Let _next_ be ? IteratorStepValue(_iteratorRecord_).
+            1. If _next_ is not ~done~, then
+              1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
+              1. Set _n_ to _n_ + 1.
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+            1. Return ? PutValue(_lref_, _A_).
+          1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
+          1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _A_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-runtime-semantics-keyeddestructuringassignmentevaluation" type="sdo">
+        <h1>
+          Runtime Semantics: KeyedDestructuringAssignmentEvaluation (
+            _value_: an ECMAScript language value,
+            _propertyName_: a property key,
+          ): either a normal completion containing ~unused~ or an abrupt completion
+        </h1>
+        <dl class="header">
+        </dl>
+        <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
+        <emu-alg>
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+            1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
+          1. Let _v_ be ? GetV(_value_, _propertyName_).
+          1. If |Initializer| is present and _v_ is *undefined*, then
+            1. If IsAnonymousFunctionDefinition(|Initializer|) and IsIdentifierRef of |DestructuringAssignmentTarget| are both *true*, then
+              1. Let _rhsValue_ be ? NamedEvaluation of |Initializer| with argument _lref_.[[ReferencedName]].
+            1. Else,
+              1. Let _defaultValue_ be ? Evaluation of |Initializer|.
+              1. Let _rhsValue_ be ? GetValue(_defaultValue_).
+          1. Else,
+            1. Let _rhsValue_ be _v_.
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+            1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
+            1. Return ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
+          1. Return ? PutValue(_lref_, _rhsValue_).
+        </emu-alg>
+      </emu-clause>
+
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -767,11 +767,36 @@ contributors: Ron Buckton, Ecma International
   <emu-clause id="sec-assignment-operators">
     <h1>Assignment Operators</h1>
 
+    <emu-clause id="sec-assignment-operators-static-semantics-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
+      <ul>
+        <li>
+          If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
+        </li>
+        <li>
+          If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+        </li>
+      </ul>
+      <emu-grammar>
+        AssignmentExpression :
+          LeftHandSideExpression AssignmentOperator AssignmentExpression
+          LeftHandSideExpression `&amp;&amp;=` AssignmentExpression
+          LeftHandSideExpression `||=` AssignmentExpression
+          LeftHandSideExpression `??=` AssignmentExpression
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+        </li>
+      </ul>
+    </emu-clause>
+
     <emu-clause id="sec-assignment-operators-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CallMemberExpression|</ins>, then
+        1. If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
           1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
             1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
@@ -939,10 +964,10 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
         <ul>
           <li>
-            If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CallMemberExpression|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
+            If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
           <li>
-            If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CallMemberExpression|</ins>, it is a Syntax Error if AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>


### PR DESCRIPTION
This fixes a typo in the assignment operator Evaluation semantics, as well as some missing static semantics and runtime semantics rules.