### PR TITLE
Add NLT to ExtractorBindingPattern, ExtractorAssignmentPattern, and ExtractorMemberExpression

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -914,9 +914,9 @@ contributors: Ron Buckton, Ecma International
 
         <ins class="block">
         ExtractorAssignmentPattern[Yield, Await] :
-          ExtractorMemberExpression[?Yield, ?Await] `(` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` AssignmentElementList[?Yield, ?Await] `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` AssignmentElementList[?Yield, ?Await] `,` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `(` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `(` AssignmentElementList[?Yield, ?Await] `)`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `(` AssignmentElementList[?Yield, ?Await] `,` Elision? AssignmentRestElement[?Yield, ?Await]? `)`
         </ins>
 
         AssignmentRestProperty[Yield, Await] :
@@ -1284,18 +1284,18 @@ contributors: Ron Buckton, Ecma International
         <ins class="block">
         <emu-grammar type="definition">
         ExtractorBindingPattern[Yield, Await] :
-          ExtractorMemberExpression[?Yield, ?Await] `(` Elision? BindingRestElement[?Yield, ?Await]? `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` BindingElementList[?Yield, ?Await] `)`
-          ExtractorMemberExpression[?Yield, ?Await] `(` BindingElementList[?Yield, ?Await] `,` Elision? BindingRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `(` Elision? BindingRestElement[?Yield, ?Await]? `)`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `(` BindingElementList[?Yield, ?Await] `)`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `(` BindingElementList[?Yield, ?Await] `,` Elision? BindingRestElement[?Yield, ?Await]? `)`
 
-        ExtractorMemberExpression[Yield, Await] :
+        ExtractorMemberExpression[Yield, Await, Assignment] :
           `this`
           MetaProperty
           IdentifierReference[?Yield, ?Await]
           `super` `.` IdentifierName
           ExtractorMemberExpression[?Yield, ?Await] `.` IdentifierName
           ExtractorMemberExpression[?Yield, ?Await] `.` PrivateIdentifier
-          ExtractorMemberExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
+          ExtractorMemberExpression[?Yield, ?Await] [no |LineTerminator| here] `[` Expression[+In, ?Yield, ?Await] `]`
         </emu-grammar>
         <emu-note type="editor">
           <p>Draft Note: The |ExtractorMemberExpression| production is equivalent to <a href="https://tc39.es/proposal-pattern-matching/#prod-PatternMatchingMemberExpression">PatternMatchingMemberExpression</a> in the <a href="https://github.com/tc39/proposal-pattern-matching">Pattern Matching</a> proposal.</p>


### PR DESCRIPTION
This adds `[no |LineTerminator| here]` assertions to _ExtractorBindingPattern_, _ExtractorAssignmentPattern_, and _ExtractorMemberExpression_ to align with Option (2) as discussed in #24:

> 1. Introduce an NLT in _ExtractorBindingPattern_ and _ExtractorAssignmentPattern_.

This is an _alternative_ solution to the one implemented in #25.

The outcome of this change is as follows:

- For
  ```js
  let x
  (a) = b
  ```
  the source is interpreted as `let x; (a) = b;` due to the NLT assertion and ASI.

- For
  ```js
  let x
  [a](b) = c
  ```
  the source is interpreted as `let x; [a](b) = c;` due to the NLT assertion and ASI. Note that `[a](b)` is not a valid _ExtractorAssignmentPattern_ as `[a]` is not a valid _ExtractorMemberExpression_ and will result in an Early Error when applying static semantics for destructuring assignment.
- For
  ```js
  let x[a]
  (b) = c
  ```
  the source is interpreted as `let x[a]; (b) = c;` due to the NLT assertion and ASI and results in a Syntax Error at parse time.

- For
  ```js
  x
  (a) = b
  ```
  the source is interpreted as `x(a) = b;` when parsing _AssignmentExpression_, but will result in an Early Error when applying static semantics for destructuring assignment since _ExtractorAssignmentPattern_ has an NLT restriction. Since this is enforced as a static semantics rule, ASI will not trigger.

- For
  ```js
  x
  [a](b) = c
  ```
  the source is interpreted as `x[a](b) = c;` when parsing _AssignmentExpression_, but will result in an Early Error when applying static semantics for destructuring assignment since _ExtractorAssignmentPattern_ has an NLT restriction. Since this is enforced as a static semantics rule, ASI will not trigger.

- For
  ```js
  x
  [a]
  (b) = c
  ```
  the source is interpreted as `x[a](b) = c;` when parsing _AssignmentExpression_, but will result in an Early Error when applying static semantics for destructuring assignment since _ExtractorAssignmentPattern_ has an NLT restriction. Since this is enforced as a static semantics rule, ASI will not trigger.

Fixes #24
Related #25