### PR TITLE
Remove unnecessary FunctionCall production

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -663,17 +663,11 @@ contributors: Ron Buckton, Ecma International
         CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] #callcover
         SuperCall[?Yield, ?Await]
         ImportCall[?Yield, ?Await]
-        <del>CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await]</del>
-        <ins>FunctionCall[?Yield, ?Await]</ins>
+        CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
         CallExpression[?Yield, ?Await] `[` Expression[+In, ?Yield, ?Await] `]`
         CallExpression[?Yield, ?Await] `.` IdentifierName
         CallExpression[?Yield, ?Await] TemplateLiteral[?Yield, ?Await, +Tagged]
         CallExpression[?Yield, ?Await] `.` PrivateIdentifier
-
-      <ins class="block">
-      FunctionCall[Yield, Await] :
-        CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
-      </ins>
 
       SuperCall[Yield, Await] :
         `super` Arguments[?Yield, ?Await]
@@ -750,8 +744,7 @@ contributors: Ron Buckton, Ecma International
         </emu-alg>
         <p>A |CallExpression| evaluation that executes step <emu-xref href="#step-callexpression-evaluation-direct-eval"></emu-xref> is a <dfn variants="direct evals">direct eval</dfn>.</p>
         <emu-grammar>
-          <del>CallExpression : CallExpression Arguments</del>
-          <ins>FunctionCall : CallExpression Arguments</ins>
+          CallExpression : CallExpression Arguments
         </emu-grammar>
         <emu-alg>
           1. Let _ref_ be ? Evaluation of |CallExpression|.
@@ -772,10 +765,10 @@ contributors: Ron Buckton, Ecma International
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <ul>
         <li>
-          If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
+          If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
         </li>
         <li>
-          If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
       <emu-grammar>
@@ -796,7 +789,7 @@ contributors: Ron Buckton, Ecma International
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+        1. If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
           1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
             1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
@@ -958,16 +951,16 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral|<del> or</del><ins>,</ins> an |ObjectLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>.
+            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral|<del> or</del><ins>,</ins> an |ObjectLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>.
           </li>
         </ul>
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
         <ul>
           <li>
-            If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
+            If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
           <li>
-            If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>
@@ -1181,7 +1174,7 @@ contributors: Ron Buckton, Ecma International
         </emu-alg>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _value_ be *undefined*.
           1. If _iteratorRecord_.[[Done]] is *false*, then
@@ -1196,7 +1189,7 @@ contributors: Ron Buckton, Ecma International
               1. Let _v_ be ? GetValue(_defaultValue_).
           1. Else,
             1. Let _v_ be _value_.
-          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
             1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
           1. Return ? PutValue(_lref_, _v_).
@@ -1206,7 +1199,7 @@ contributors: Ron Buckton, Ecma International
         </emu-note>
         <emu-grammar>AssignmentRestElement : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
@@ -1215,7 +1208,7 @@ contributors: Ron Buckton, Ecma International
             1. If _next_ is not ~done~, then
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
               1. Set _n_ to _n_ + 1.
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
             1. Return ? PutValue(_lref_, _A_).
           1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
           1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _A_.
@@ -1233,7 +1226,7 @@ contributors: Ron Buckton, Ecma International
         </dl>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
@@ -1244,7 +1237,7 @@ contributors: Ron Buckton, Ecma International
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
           1. Else,
             1. Let _rhsValue_ be _v_.
-          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, a |FunctionCall|, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
           1. Return ? PutValue(_lref_, _rhsValue_).


### PR DESCRIPTION
Since extractors can't be `a()(b) = c`, the _FunctionCall_ production is redundant and can be removed.